### PR TITLE
update agents logging for better obeservability

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ CLI Options
 | `--data-dir` | `-d` | Data directory to upload | Current directory (with confirmation) |
 | `--session-id` | `-s` | Reuse existing session ID | Auto-generated |
 | `--help` | `-h` | Show help message | - |
-| `--save-trace` | - | Save query/execution trace as JSONL and a Markdown log (`log-*.md`) in the current directory | Disabled |
+| `--save-trace` | - | Save query/execution trace as `log-trace_*.jsonl` and a Markdown log `log-trace_*.md` in the current directory | Disabled |
 
 
 2. Python API: For programmatic usage, you can also use the Python API directly

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ CLI Options
 | `--data-dir` | `-d` | Data directory to upload | Current directory (with confirmation) |
 | `--session-id` | `-s` | Reuse existing session ID | Auto-generated |
 | `--help` | `-h` | Show help message | - |
+| `--save-trace` | - | Save query/execution trace as JSONL and a Markdown log (`log-*.md`) in the current directory | Disabled |
 
 
 2. Python API: For programmatic usage, you can also use the Python API directly

--- a/open_data_scientist/cli.py
+++ b/open_data_scientist/cli.py
@@ -104,8 +104,7 @@ def show_configuration(args) -> None:
     table.add_row(
         "Data Directory", args.data_dir or "Current directory (with confirmation)"
     )
-    table.add_row("Trace File", args.trace_path or "Disabled")
-    table.add_row("Log File", args.log_path or "Disabled")
+    table.add_row("Trace Log", args.trace_path or "Disabled")
 
     console.print(table)
     console.print()
@@ -194,21 +193,16 @@ Execution Modes:
     data_dir = get_data_directory(args.data_dir)
 
     trace_path = None
+    trace_base = None
     if args.save_trace:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        trace_path = str(Path.cwd() / f"react_trace_{timestamp}.jsonl")
-
-    log_path = None
-    if args.save_trace:
-        # Use same timestamp as trace_path to keep files paired
-        timestamp = Path(trace_path).stem.split("_", 2)[-1] if trace_path else datetime.now().strftime("%Y%m%d_%H%M%S")
-        log_path = str(Path.cwd() / f"log-{timestamp}.md")
+        trace_base = str(Path.cwd() / f"log-trace_{timestamp}")
+        trace_path = f"{trace_base}.jsonl"
 
     # Show configuration
     # Update args for display
     args.data_dir = (Path(data_dir).name if data_dir else "None (no files will be uploaded)")
-    args.trace_path = trace_path
-    args.log_path = log_path
+    args.trace_path = trace_base
     show_configuration(args)
 
     # Ask for confirmation
@@ -222,10 +216,8 @@ Execution Modes:
         welcome_text += f"\n📁 Data from: {Path(data_dir).name}"
     welcome_text += f"\n🧠 Model: {args.model}"
     welcome_text += f"\n⚡ Executor: {args.executor.upper()}"
-    if trace_path:
-        welcome_text += f"\nTrace: {Path(trace_path).name}"
-    if log_path:
-        welcome_text += f"\nLog: {Path(log_path).name}"
+    if trace_base:
+        welcome_text += f"\nTrace Log: {Path(trace_base).name}"
 
     welcome_panel = Panel(
         welcome_text,
@@ -255,7 +247,6 @@ Execution Modes:
             executor=args.executor,
             data_dir=data_dir,
             trace_path=trace_path,
-            log_path=log_path,
         )
 
     except Exception as e:

--- a/open_data_scientist/utils/strings.py
+++ b/open_data_scientist/utils/strings.py
@@ -257,9 +257,16 @@ def get_execution_summary(execution_result: Dict, max_chars_before_truncation) -
     # Add display outputs (plots, images) - include saved filenames
     if parsed.display_outputs:
         summary_parts.append("Visual outputs:")
-        for i, display_output in enumerate(parsed.display_outputs):
-            if display_output == "Generated plot/image" and i < len(saved_image_filenames):
-                summary_parts.append(f"{display_output} (saved as: {saved_image_filenames[i]})")
+        image_index = 0
+        for display_output in parsed.display_outputs:
+            if (
+                display_output == "Generated plot/image"
+                and image_index < len(saved_image_filenames)
+            ):
+                summary_parts.append(
+                    f"{display_output} (saved as: {saved_image_filenames[image_index]})"
+                )
+                image_index += 1
             else:
                 summary_parts.append(display_output)
 

--- a/open_data_scientist/utils/writer.py
+++ b/open_data_scientist/utils/writer.py
@@ -32,7 +32,7 @@ def _write_report(user_input, result, history, model="deepseek-ai/DeepSeek-V3"):
     )
     output_report : str = response.choices[0].message.content  # type: ignore
 
-    report_name = f"{sanitize_filename(user_input)}.md"
+    report_name = f"report-{sanitize_filename(user_input)}.md"
     
     with open(report_name, "w") as f:
         f.write(output_report)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds optional, persistent tracing for better observability.
> 
> - New `--save-trace` CLI flag creates timestamped `log-trace_*.jsonl` and `log-trace_*.md` files; config table and welcome panel show trace status
> - Agent logs structured events (`query`, `step`, `error`, `final_answer`, `max_iterations`, `run_end`) via `_record_event` and renders a readable Markdown log in `_render_log`, including embedded saved image references
> - `ReActDataScienceAgent` updated with `trace_path`/`log_path`, executor type tracking, and image filename extraction from observations
> - Improves output summarization to correctly map multiple images; report files now named `report-<sanitized>.md`
> - README updated to document the new flag and minor formatting fixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fded845a43ddae43add20d1b41394c503342bcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->